### PR TITLE
Remove (r) from plugin title in readme.txt

### DIFF
--- a/ezphp/readme.txt
+++ b/ezphp/readme.txt
@@ -1,4 +1,4 @@
-=== ezPHP for WordPress® ===
+=== ezPHP for WordPress ===
 
 Contributors: WebSharks
 Donate link: http://www.s2member.com/donate/


### PR DESCRIPTION
The ® character causes problems in certain places on WordPress.org ([my favorited plugins](http://profiles.wordpress.org/raamdev/), for example). See screenshot below:

![screen shot 2013-10-29 at 11 57 14 am](https://f.cloud.github.com/assets/53005/1429647/7e4fb4de-40b5-11e3-8476-1733b348f492.png)
